### PR TITLE
use correct SPDX license identifier

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "slug": "Moffenzeef",
   "name": "Moffenzeef",
   "version": "2.0.0",
-  "license": "GPL-3.0+",
+  "license": "GPL-3.0-or-later",
   "brand": "Moffenzeef",
   "author": "Ross Fish",
   "authorEmail": "moffenzeefmodular@gmail.com",


### PR DESCRIPTION
`GPL-3.0+` has been deprecated as a license identifier and superseded by `GPL-3.0-or-later`